### PR TITLE
Typecast dynamic promises to int (resolves #75)

### DIFF
--- a/src/protect/alignment/common.py
+++ b/src/protect/alignment/common.py
@@ -21,7 +21,7 @@ import os
 
 # disk for indexing
 def index_disk(bamfile):
-    return ceil(bamfile.size + 524288)
+    return int(ceil(bamfile.size + 524288))
 
 
 def index_bamfile(job, bamfile, sample_type, univ_options):

--- a/src/protect/alignment/dna.py
+++ b/src/protect/alignment/dna.py
@@ -23,19 +23,20 @@ import os
 
 # disk for bwa-related functions
 def bwa_disk(dna_fastqs, bwa_index):
-    return 6 * ceil(sum([f.size for f in dna_fastqs]) + 524288) + 2 * ceil(bwa_index.size + 524288)
+    return int(6 * ceil(sum([f.size for f in dna_fastqs]) + 524288) +
+               2 * ceil(bwa_index.size + 524288))
 
 
 def sam2bam_disk(samfile):
-    return ceil(1.5 * samfile.size + 524288)
+    return int(ceil(1.5 * samfile.size + 524288))
 
 
 def reheader_disk(bamfile):
-    return ceil(2 * bamfile.size + 524288)
+    return int(ceil(2 * bamfile.size + 524288))
 
 
 def regroup_disk(reheader_bam):
-    return ceil(4 * reheader_bam.size + 524288)
+    return int(ceil(4 * reheader_bam.size + 524288))
 
 
 def align_dna(job, fastqs, sample_type, univ_options, bwa_options):

--- a/src/protect/alignment/rna.py
+++ b/src/protect/alignment/rna.py
@@ -24,8 +24,9 @@ import os
 
 # disk for star
 def star_disk(rna_fastqs, star_tar):
-    return (4 * ceil(sum([f.size for f in rna_fastqs]) + 524288) + 2 * ceil(star_tar.size +
-                                                                            524288) + 5242880)
+    return int(4 * ceil(sum([f.size for f in rna_fastqs]) + 524288) +
+               2 * ceil(star_tar.size + 524288) +
+               5242880)
 
 
 def align_rna(job, fastqs, univ_options, star_options):

--- a/src/protect/expression_profiling/rsem.py
+++ b/src/protect/expression_profiling/rsem.py
@@ -24,7 +24,8 @@ import sys
 # disk for rsem
 def rsem_disk(star_bam, rsem_index):
     star_transcriptome_bam = star_bam['rnaAligned.sortedByCoord.out.bam']['rna_fix_pg_sorted.bam']
-    return 3 * ceil(star_transcriptome_bam.size + 524288) + 4 * ceil(rsem_index.size + 524288)
+    return int(3 * ceil(star_transcriptome_bam.size + 524288) +
+               4 * ceil(rsem_index.size + 524288))
 
 
 def wrap_rsem(job, star_bams, univ_options, rsem_options):

--- a/src/protect/haplotyping/phlat.py
+++ b/src/protect/haplotyping/phlat.py
@@ -25,7 +25,8 @@ import sys
 
 # disk for phlat
 def phlat_disk(rna_fastqs):
-    return ceil(sum([f.size for f in rna_fastqs]) + 524288) + 8053063680
+    return int(ceil(sum([f.size for f in rna_fastqs]) + 524288) +
+               8053063680)
 
 
 def run_phlat(job, fastqs, sample_type, univ_options, phlat_options):

--- a/src/protect/mutation_annotation/snpeff.py
+++ b/src/protect/mutation_annotation/snpeff.py
@@ -22,7 +22,7 @@ import os
 
 # disk for snpeff.
 def snpeff_disk(snpeff_index):
-    return 6 * ceil(snpeff_index.size + 524288)
+    return int(6 * ceil(snpeff_index.size + 524288))
 
 
 def run_snpeff(job, merged_mutation_file, univ_options, snpeff_options):

--- a/src/protect/mutation_calling/muse.py
+++ b/src/protect/mutation_calling/muse.py
@@ -28,11 +28,13 @@ import time
 
 # disk for muse and muse_sump.
 def muse_disk(tumor_bam, normal_bam, fasta):
-    return ceil(tumor_bam.size) + ceil(normal_bam.size) + 4 * ceil(fasta.size)
+    return int(ceil(tumor_bam.size) +
+               ceil(normal_bam.size) +
+               4 * ceil(fasta.size))
 
 
 def muse_sump_disk(dbsnp):
-    return ceil(dbsnp.size) + 524288
+    return int(ceil(dbsnp.size + 524288))
 
 
 def run_muse_with_merge(job, tumor_bam, normal_bam, univ_options, muse_options):

--- a/src/protect/mutation_calling/mutect.py
+++ b/src/protect/mutation_calling/mutect.py
@@ -28,8 +28,11 @@ from toil.job import PromisedRequirement
 
 
 def mutect_disk(tumor_bam, normal_bam, fasta, dbsnp, cosmic):
-    return (ceil(tumor_bam.size) + ceil(normal_bam.size) + 4 * ceil(fasta.size) +
-            10 * ceil(dbsnp.size) + 2 * ceil(cosmic.size))
+    return int(ceil(tumor_bam.size) +
+               ceil(normal_bam.size) +
+               4 * ceil(fasta.size) +
+               10 * ceil(dbsnp.size) +
+               2 * ceil(cosmic.size))
 
 
 def run_mutect_with_merge(job, tumor_bam, normal_bam, univ_options, mutect_options):

--- a/src/protect/mutation_calling/radia.py
+++ b/src/protect/mutation_calling/radia.py
@@ -28,7 +28,10 @@ from toil.job import PromisedRequirement
 
 
 def radia_disk(tumor_bam, normal_bam, rna_bam, fasta):
-    return ceil(tumor_bam.size) + ceil(normal_bam.size) + ceil(rna_bam.size) + 4 * ceil(fasta.size)
+    return int(ceil(tumor_bam.size) +
+               ceil(normal_bam.size) +
+               ceil(rna_bam.size) +
+               4 * ceil(fasta.size))
 
 
 def run_radia_with_merge(job, rna_bam, tumor_bam, normal_bam, univ_options, radia_options):

--- a/src/protect/mutation_calling/somaticsniper.py
+++ b/src/protect/mutation_calling/somaticsniper.py
@@ -29,15 +29,19 @@ import os
 
 # disk for somatic sniper, and for filtering
 def sniper_disk(tumor_bam, normal_bam, fasta):
-    return ceil(tumor_bam.size) + ceil(normal_bam.size) + 4 * ceil(fasta.size)
+    return int(ceil(tumor_bam.size) +
+               ceil(normal_bam.size) +
+               4 * ceil(fasta.size))
 
 
 def pileup_disk(tumor_bam, fasta):
-    return ceil(tumor_bam.size) + 2 * ceil(fasta.size)
+    return int(ceil(tumor_bam.size) +
+               2 * ceil(fasta.size))
 
 
 def sniper_filter_disk(tumor_bam, fasta):
-    return ceil(tumor_bam.size) + 2 * ceil(fasta.size)
+    return int(ceil(tumor_bam.size) +
+               2 * ceil(fasta.size))
 
 
 # Somatic Sniper is a different tool from the other callers because it is run in full

--- a/src/protect/qc/rna.py
+++ b/src/protect/qc/rna.py
@@ -21,7 +21,7 @@ import os
 
 # disk for cutadapt
 def cutadapt_disk(rna_fastqs):
-    return 2 * ceil(sum([f.size for f in rna_fastqs]) + 524288)
+    return int(2 * ceil(sum([f.size for f in rna_fastqs]) + 524288))
 
 
 def run_cutadapt(job, fastqs, univ_options, cutadapt_options):

--- a/src/protect/version.py
+++ b/src/protect/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '2.1.1'
+version = '2.1.2a1'


### PR DESCRIPTION
resolves #75

Toil cannot handle floats in scientific notation for memory and disk, and really, fractions of ram
or disk are not logical so we shouldn't be using them anyway.