### PR TITLE
Prevent virtualenv from installing latest setuptools (resolves #109)

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -15,7 +15,7 @@ ln -snf ${TMPDIR}/s3am/bin/s3am ${TMPDIR}/bin/
 export PATH=$PATH:${TMPDIR}/bin
 
 # Install Toil in a venv then install ProTECT
-virtualenv venv
+virtualenv --never-download venv
 . venv/bin/activate
 
 pip install toil==3.3.0


### PR DESCRIPTION
resolves #109

This fixes a  problem with `setup.py upload` not being able to read the credentials from ~/.pypirc anymore.