### PR TITLE
Improve fastq download support(resolves #152, #153)

### DIFF
--- a/src/protect/pipeline/input_parameters.yaml
+++ b/src/protect/pipeline/input_parameters.yaml
@@ -33,6 +33,7 @@ patients:
         tumor_dna_fastq_1: /path/to/<tumor_dna_prefix>1.fastq.gz
         normal_dna_fastq_1: /path/to/<normal_dna_prefix>1.fastq.gz
         tumor_rna_fastq_1: /path/to/<tumor_rna_prefix>1.fastq.gz
+        # ssec_encrypted: True
     PRTCT-02:
         # The paths can also be to directories on S3 as
         tumor_dna_fastq_1: S3://bucket/path/to/<tumor_dna_prefix>1.fastq.gz

--- a/src/protect/test/test_inputs/ci_parameters.yaml
+++ b/src/protect/test/test_inputs/ci_parameters.yaml
@@ -31,6 +31,7 @@
 patients:
     TEST:
         tumor_dna_fastq_1 : S3://cgl-protect-data/ci_references/Tum_1.fq.gz
+        tumor_dna_fastq_2 : S3://cgl-protect-data/ci_references/Tum_2.fq.gz
         normal_dna_fastq_1 : S3://cgl-protect-data/ci_references/Norm_1.fq.gz
         tumor_rna_fastq_1 : S3://cgl-protect-data/ci_references/Rna_1.fq.gz
 


### PR DESCRIPTION
resolves #152
resolves #153

Allow user to specify _1.fastq and _2.fastq so they don't have to have the same form anymore
Allow users to process a mixture of samples of encrypted and non-encrypted/sse-s3 encrypted data at the same time.