### PR TITLE
Bump Transgene default to 2.0.0 (Resolves #158)

### DIFF
--- a/required_docker_tools.txt
+++ b/required_docker_tools.txt
@@ -35,7 +35,7 @@
 	snpeff:3.6
 
 # Mutation Translation
-	transgene:1.0.0
+	transgene:2.0.0
 
 # MHC:peptide binding prediction
 	mhci:2.13

--- a/src/protect/pipeline/defaults.yaml
+++ b/src/protect/pipeline/defaults.yaml
@@ -75,7 +75,7 @@ mutation_annotation:
 
 mutation_translation:
     transgene:
-        version: 1.0.0
+        version: 2.0.0
 
 haplotyping:
     phlat:

--- a/src/protect/pipeline/input_parameters.yaml
+++ b/src/protect/pipeline/input_parameters.yaml
@@ -112,7 +112,7 @@ mutation_annotation:
 mutation_translation:
     transgene:
         gencode_peptide_fasta: S3://cgl-protect-data/hg19_references/gencode.v19.pc_translations_NOPARY.fa.tar.gz
-        # version: 1.0.0
+        # version: 2.0.0
 
 haplotyping:
     phlat:


### PR DESCRIPTION
Resolves #158

Transgene dockers were mislabelled at when docker defaults were committed. This fixes the
wrong label