### PR TITLE
Update rankboost to 2.1.1 (resolves #234)

### DIFF
--- a/required_docker_tools.txt
+++ b/required_docker_tools.txt
@@ -43,4 +43,4 @@
 	netmhciipan:3.1
 
 # Prediction Ranking
-	rankboost:2.0.3
+	rankboost:2.1.1

--- a/src/protect/pipeline/defaults.yaml
+++ b/src/protect/pipeline/defaults.yaml
@@ -118,4 +118,4 @@ prediction_ranking:
             nMHC: 0.2
             TPM: 0.2
             tndelta: 0.2
-        version: 2.1.0
+        version: 2.1.1


### PR DESCRIPTION
resolves #234
related to arkal/rankboost#6

Update rankboost version to handle duped neoepitopes after trimming unused AAs