### PR TITLE
Update make-prepare to install toil 3.8.0 (resolves #260)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ normal=\033[0m
 red=\033[0;31m
 
 prepare: check_venv
-	@$(pip) install toil==3.5.2 pytest==2.8.3
+	@$(pip) install toil==3.8.0 pytest==2.8.3
 
 develop: check_venv
 	$(pip) install -e .$(extras)


### PR DESCRIPTION
resolves #260 

Modified Makefile so make-prepare installs up to date toil version.